### PR TITLE
Fix PHPMailer path casing

### DIFF
--- a/controllers/CorreoController.php
+++ b/controllers/CorreoController.php
@@ -1,8 +1,8 @@
 <?php
 require_once 'libs/fpdf/fpdf.php';
-require_once 'libs/phpmailer/PHPMailer.php';
-require_once 'libs/phpmailer/SMTP.php';
-require_once 'libs/phpmailer/Exception.php';
+require_once 'libs/phpMailer/PHPMailer.php';
+require_once 'libs/phpMailer/SMTP.php';
+require_once 'libs/phpMailer/Exception.php';
 require_once 'helpers/auth.php';
 
 use PHPMailer\PHPMailer\PHPMailer;

--- a/helpers/email.php
+++ b/helpers/email.php
@@ -2,9 +2,9 @@
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 
-require_once 'libs/phpmailer/PHPMailer.php';
-require_once 'libs/phpmailer/SMTP.php';
-require_once 'libs/phpmailer/Exception.php';
+require_once 'libs/phpMailer/PHPMailer.php';
+require_once 'libs/phpMailer/SMTP.php';
+require_once 'libs/phpMailer/Exception.php';
 
 // 📬 Envía el PDF del préstamo al correo del usuario
 function enviarCorreoConPDF($correoDestino, $rutaPDF, $nombre = "Empleado", $asunto = "Resumen de préstamo")


### PR DESCRIPTION
## Summary
- fix incorrect case in PHPMailer include paths

## Testing
- `python -m py_compile scripts/cron_alertas_ai.py`
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b9c66db688323baa38d1457d79883