### PR TITLE
Add admin-only user registration

### DIFF
--- a/controllers/UsuarioController.php
+++ b/controllers/UsuarioController.php
@@ -182,4 +182,42 @@ class UsuarioController
 
         require 'views/usuarios/firma.php';
     }
+
+    // 🆕 Formulario para dar de alta a un nuevo usuario (solo administradores)
+    public function nuevo()
+    {
+        if (!esAdministrador()) {
+            header('Location: index.php?c=auth&a=login');
+            exit;
+        }
+
+        require 'views/usuarios/nuevo.php';
+    }
+
+    // 🆕 Procesa el alta de un nuevo usuario
+    public function guardar()
+    {
+        if ($_SERVER['REQUEST_METHOD'] === 'POST' && esAdministrador()) {
+            $nombre      = trim($_POST['nombre'] ?? '');
+            $email       = trim($_POST['email'] ?? '');
+            $contrasena  = $_POST['contrasena'] ?? '';
+            $rol         = $_POST['rol'] ?? 'empleado';
+
+            if ($nombre === '' || $email === '' || $contrasena === '') {
+                $_SESSION['error'] = 'Todos los campos son obligatorios.';
+                require 'views/usuarios/nuevo.php';
+                return;
+            }
+
+            if (Usuario::existeEmail($email)) {
+                $_SESSION['error'] = 'El email ya está registrado.';
+                require 'views/usuarios/nuevo.php';
+                return;
+            }
+
+            Usuario::crear($nombre, $email, $contrasena, $rol);
+            header('Location: index.php?c=prestamo&a=dashboard');
+            exit;
+        }
+    }
 }

--- a/models/Usuario.php
+++ b/models/Usuario.php
@@ -23,4 +23,27 @@ class Usuario
         $sql = "SELECT id, nombre, email FROM usuarios";
         return $conn->query($sql)->fetch_all(MYSQLI_ASSOC);
     }
+
+    // Comprueba si existe un usuario con el email indicado
+    public static function existeEmail($email)
+    {
+        require 'config/database.php';
+        $stmt = $conn->prepare("SELECT id FROM usuarios WHERE email = ?");
+        $stmt->bind_param("s", $email);
+        $stmt->execute();
+        $stmt->store_result();
+        return $stmt->num_rows > 0;
+    }
+
+    // Crea un nuevo usuario en la base de datos
+    public static function crear($nombre, $email, $contrasena, $rol)
+    {
+        require 'config/database.php';
+        $hash = password_hash($contrasena, PASSWORD_DEFAULT);
+        $stmt = $conn->prepare(
+            "INSERT INTO usuarios (nombre, email, contraseña, rol) VALUES (?, ?, ?, ?)"
+        );
+        $stmt->bind_param("ssss", $nombre, $email, $hash, $rol);
+        $stmt->execute();
+    }
 }

--- a/views/dashboard.php
+++ b/views/dashboard.php
@@ -139,6 +139,18 @@
           </a>
         </div>
 
+        <?php if ($_SESSION['rol'] === 'administrador'): ?>
+        <!-- Alta de usuarios -->
+        <div class="col-md-4">
+          <a href="index.php?c=usuario&a=nuevo" class="text-decoration-none text-dark">
+            <div class="card text-center p-4 dashboard-card shadow-sm">
+              <div class="dashboard-icon"><i class="bi bi-person-plus"></i></div>
+              <h5 class="card-title">Alta de usuarios</h5>
+            </div>
+          </a>
+        </div>
+        <?php endif; ?>
+
         <!-- Nueva: Alertas de Seguridad -->
         <div class="col-md-4">
           <a href="index.php?c=alertas&a=index" class="text-decoration-none text-dark">

--- a/views/usuarios/nuevo.php
+++ b/views/usuarios/nuevo.php
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Registrar Usuario</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <!-- CSS para modo oscuro -->
+  <link rel="stylesheet" href="public/css/tema.css">
+</head>
+<body class="bg-light">
+  <div class="container mt-5">
+    <h2 class="mb-4">Dar de alta nuevo usuario</h2>
+    <div class="d-flex justify-content-end align-items-center gap-2 mb-3">
+      <a href="index.php?c=prestamo&a=dashboard" class="btn btn-outline-secondary">← Volver</a>
+      <button id="toggle-dark-mode" class="btn btn-outline-secondary">🌓 Modo oscuro</button>
+    </div>
+
+    <?php if (!empty($_SESSION['error'])): ?>
+      <div class="alert alert-danger"><?= $_SESSION['error']; unset($_SESSION['error']); ?></div>
+    <?php endif; ?>
+
+    <form method="POST" action="index.php?c=usuario&a=guardar" class="card p-4 shadow-sm">
+      <div class="mb-3">
+        <label class="form-label">Nombre</label>
+        <input type="text" name="nombre" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input type="email" name="email" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Contraseña</label>
+        <input type="password" name="contrasena" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Rol</label>
+        <select name="rol" class="form-select">
+          <option value="empleado">Empleado</option>
+          <option value="tecnico">Técnico</option>
+          <option value="administrador">Administrador</option>
+        </select>
+      </div>
+      <button type="submit" class="btn btn-success w-100">Registrar</button>
+    </form>
+  </div>
+
+  <script src="public/js/tema.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow creation of new users from dashboard
- implement `Usuario::existeEmail` and `Usuario::crear`
- add controller actions to show the form and save the user
- create the user registration view
- include admin-only card in dashboard

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cbb610c4c8323a8f1c51d6d6cf144